### PR TITLE
Fallback Map

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,12 +39,17 @@ app.get('/details', (req, res) => {
 
 app.post('/refresh', (req, res) => {
   Crawler.refresh()
-  res.send("Refresh lanched")
+  res.send("Refresh launched\n")
 });
 
 app.get('/info', (req, res) => {
   res.append('Content-Type', 'application/json')
   Crawler.getInfoByCoord(req.query.col, req.query.row).then(d => res.send(d))
+})
+
+app.get('/allinfo', (req, res) => {
+  res.append('Content-Type', 'application/json')
+  Crawler.getAllInfo().then(d => res.send(d))
 })
 
 app.get('/stats', (req, res) => {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ app.get('/map', (req, res) => {
   res.sendFile(path.join(__dirname, 'save/map.png'));
 });
 
+app.get('/blankmap', (req, res) => {
+  res.sendFile(path.join(__dirname, 'save/blankmap.png'));
+});
+
 app.get('/script', (req, res) => {
   res.sendFile(path.join(__dirname, 'compile/script.front.js'));
 });

--- a/src/back/Crawler.js
+++ b/src/back/Crawler.js
@@ -160,7 +160,7 @@ function refresh() {
     }).run((error, result) => {
       if(error) console.error(error)
       result = JSON.parse(result);
-      for(race in result.Status) {
+      for(race of ["Humans", "Halflings", "Dwarves", "Elves"]) {
         result.Status[race] = parser(result.Status[race])
       }
       request(result.MapUrl).pipe(fs.createWriteStream('save/map.png'));

--- a/src/back/Crawler.js
+++ b/src/back/Crawler.js
@@ -278,9 +278,13 @@ function refresh() {
       result.Structures = structureParser(result.Structures)
       refreshTurn(result.Turns[result.Turns.length - 1]);
 
+      request(result.MapUrl).pipe(fs.createWriteStream('save/blankmap.png'));
+
       (new StatusMongoose({
         date: new Date(),
-        Survivors: result.Survivors,
+        Survivors: [...result.Survivors,
+                    ...result.LooseItems,
+                    ...result.Structures],
         Craft: result.Crafting,
         Magic: result.Magic
       })).save().then(_ => console.info("Updated"));

--- a/src/back/Crawler.js
+++ b/src/back/Crawler.js
@@ -238,7 +238,10 @@ function getDetailsAboutStat(stat) {
           const count = [...survivor.items, ...survivor.condition]
             .filter(elem => elem === stat)
             .length
-          details.push([survivor.Name, count])
+          details.push([survivor.Name,
+                        survivor.Position.x,
+                        survivor.Position.y,
+                        count])
         }
       }
       resolve(details)

--- a/src/back/Crawler.js
+++ b/src/back/Crawler.js
@@ -211,7 +211,7 @@ function getCounts() {
           for (const item of counting) {
             if (!item) continue
             if (item in acc) acc[item]++
-            else acc[item] = 0
+            else acc[item] = 1
           }
           return acc
         }, {})

--- a/src/back/Crawler.js
+++ b/src/back/Crawler.js
@@ -241,6 +241,21 @@ function refresh() {
     }).end()
 }
 
+function getAllInfo() {
+  return new Promise((resolve, reject) => {
+    StatusMongoose.find({}, ['Survivors'], {
+      skip:0,
+      limit: 1,
+      sort: {
+        date: -1
+      },
+    }, (err, stat) => {
+      if(err) { reject(err) }
+      resolve(stat[0].Survivors)
+    })
+  })
+}
+
 function getInfoByCoord(x, y) {
   return new Promise((resolve, reject) => {
     StatusMongoose.find({}, ['Survivors'], {
@@ -317,6 +332,7 @@ module.exports = {
   getDetailsAboutStat,
   getCounts,
   getInfoByCoord,
+  getAllInfo,
   Position,
   Inhabitant,
   refresh,

--- a/src/back/Crawler.js
+++ b/src/back/Crawler.js
@@ -68,7 +68,7 @@ const StatusMongoose = mongoose.model('Status', {
 })
 
 
-function parser(data) {
+function survivorParser(data) {
   const ConditionsRegex = /Conditions: *((?:\w*[, ]?)*)/
   const ItemsRegex = /Items: *((?:\w*[, ]?)*)/
   const PosRegex = /Position: *(\d+), *(\d+)/
@@ -117,6 +117,66 @@ function parser(data) {
   return Inhabitants
 }
 
+function looseParser(data) {
+  const LooseItems = new Array();
+  const PosRegex = /(\d+), *(\d+) *:/;
+  const ItemsRegex = /\d+ [\w ]+,?/g;
+  const ItemRegex = /(\d+) ([\w ]+)/;
+
+  const lines = data.split(/\n/);
+  for (const line of lines) {
+    try {
+      const position = line.match(PosRegex);
+      const items = [];
+      for (const item of line.match(ItemsRegex)) {
+        const itemMatch = item.match(ItemRegex);
+        for (let count = 0; count < Number(itemMatch[1]); count++) {
+          items.push(itemMatch[2]);
+        }
+      }
+      LooseItems.push(new Inhabitant (
+        "Loose Items",
+        "",
+        position[1],
+        position[2],
+        0, 0, // Health, not valid
+        items,
+        ["Loose"]
+      ));
+    } catch (e) {
+      console.error(e);
+      console.error(line);
+    }
+  }
+  return LooseItems;
+}
+
+function structureParser(data) {
+  const Structures = new Array();
+  const PosRegex = /(\d+), *(\d+) *:/;
+
+  const lines = data.split(/\n/);
+  for (const line of lines) {
+    try {
+      const position = line.match(PosRegex);
+      const name = line.split(/:/)[1];
+      Structures.push(new Inhabitant (
+        name,
+        "Structure",
+        position[1],
+        position[2],
+        0, 0, // TODO: Parse health once we have example
+        [""],
+        ["Structure"]
+      ));
+    } catch (e) {
+      console.error(e);
+      console.error(line);
+    }
+  }
+  return Structures;
+}
+
 function refresh() {
   console.info("Update started")
   return nightmare
@@ -161,8 +221,10 @@ function refresh() {
       if(error) console.error(error)
       result = JSON.parse(result);
       for(race of ["Humans", "Halflings", "Dwarves", "Elves"]) {
-        result.Status[race] = parser(result.Status[race])
+        result.Status[race] = survivorParser(result.Status[race])
       }
+      result.Status.LooseItems = looseParser(result.Status["Loose Items"])
+      result.Status.Structures = structureParser(result.Status["Structures"])
       request(result.MapUrl).pipe(fs.createWriteStream('save/map.png'));
 
       (new StatusMongoose({
@@ -170,7 +232,9 @@ function refresh() {
         Survivors: [...result.Status.Humans,
                     ...result.Status.Halflings,
                     ...result.Status.Dwarves,
-                    ...result.Status.Elves],
+                    ...result.Status.Elves,
+                    ...result.Status.LooseItems,
+                    ...result.Status.Structures],
         Craft: result.Crafting,
         Magic: result.Magic
       })).save().then(_ => console.info("Updated"));

--- a/src/front/css/style.css
+++ b/src/front/css/style.css
@@ -31,6 +31,12 @@ body, html {
   align-items: baseline;
 }
 
+#dataButton {
+  margin-left: auto;
+  margin-right: auto;
+  padding: 4px 10px;
+}
+
 #stats {
   margin-left: 30px;
   margin-right: 30px;

--- a/src/front/css/style.css
+++ b/src/front/css/style.css
@@ -60,6 +60,10 @@ ul {
   background-color: #444444;
 }
 
+.location:hover {
+  background-color: #444444;
+}
+
 caption {
   padding: 5px;
 }

--- a/src/front/css/style.css
+++ b/src/front/css/style.css
@@ -20,12 +20,15 @@ body, html {
   margin-right: auto;
   cursor: pointer;
 }
+
 #data {
   margin-left: 30px;
   margin-right: 30px;
   color: white;
-  display:flex;
-  justify-content: space-evenly;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  align-items: baseline;
 }
 
 #stats {
@@ -38,7 +41,7 @@ body, html {
 }
 
 ul {
-  color:inherit;
+  color: inherit;
   list-style: none;
   font-family: monospace;
 }

--- a/src/front/css/style.css
+++ b/src/front/css/style.css
@@ -48,7 +48,7 @@ data-card:hover {
   background-color: #444444;
 }
 
-#dataButton {
+button {
   margin-top: 10px;
   margin-bottom: 10px;
   margin-right: 15px;
@@ -60,7 +60,7 @@ data-card:hover {
   font-family: inherit;
 }
 
-#dataButton:active {
+button:active, button.current {
   background-color: white;
   color: black;
 }

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -103,7 +103,6 @@ map.load('/map', 962, 924, 0, 0).then(_ => {
     }
 
     canvas.addEventListener('mousemove', e => {
-
       const { x, y } = translateCoordinate(e.offsetX, e.offsetY)
 
       let hexa = hexagons.find(h => h.isIn(x, y))

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -8,11 +8,16 @@ import Requests from './init.js'
 const canvas = document.querySelector("canvas#map")
 
 const drawer = new Drawer(canvas);
-const map = new Images()
+const markmap = new Images()
+const blankmap = new Images();
+let map = markmap;
 
 const data = document.querySelector("div#data")
 const dataBlueprint = document.querySelector("div.data")
 const dataButton = document.querySelector("button#dataButton")
+
+const markButton = document.querySelector("button#markButton")
+const blankButton = document.querySelector("button#blankButton")
 
 const stats = document.querySelector("div#stats")
 
@@ -65,14 +70,15 @@ function getSurvivors(x,y) {
 
 dataButton.addEventListener('click', e => getSurvivors());
 
-map.load('/map', 962, 924, 0, 0).then(_ => {
-
-  console.log("Map loaded");
+function drawMap(m) {
+  map = m;
   drawer.setSize(map.width, map.height);
+  drawer.clean();
   drawer.drawImageScale(0,0,1,map);
-  console.log("Map drawed");
+}
 
-
+markmap.load('/map', 962, 924, 0, 0).then(_ => {
+  drawMap(markmap);
 
   fetchMetadata().then(metadata => {
     for(let row = 1; row <= 71; row++) {
@@ -141,6 +147,20 @@ map.load('/map', 962, 924, 0, 0).then(_ => {
       }
     })
   })
+
+  markButton.addEventListener('click', e => {
+    drawMap(markmap);
+    markButton.className = "current";
+    blankButton.className = "";
+  });
+}, e => console.error(e));
+
+blankmap.load('/blankmap', 962, 924, 0, 0).then(_ => {
+  blankButton.addEventListener('click', e => {
+    drawMap(blankmap);
+    markButton.className = "";
+    blankButton.className = "current";
+  });
 }, e => console.error(e));
 
 fetch(Requests.StatsRequest()).then(d => d.json()).then(d => {

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -66,10 +66,10 @@ function getSurvivors(x,y) {
           .fill({
             Name: inhab.Name,
             Description: inhab.Description,
-            Postion: `${inhab.Position.x},${inhab.Position.y}`,
+            Position: `${inhab.Position.x},${inhab.Position.y}`,
             Health: `${inhab.Health}/${inhab.MaxHealth}`,
-            Items: inhab.items.toString(),
-            Conditions: inhab.condition.toString()
+            Items: inhab.items.toString().replace(/,/g,', '),
+            Conditions: inhab.condition.toString().replace(/,/g,', ')
           }).appendIn(data)
       }
     })
@@ -103,6 +103,7 @@ map.load('/map', 962, 924, 0, 0).then(_ => {
     }
 
     canvas.addEventListener('mousemove', e => {
+
       const { x, y } = translateCoordinate(e.offsetX, e.offsetY)
 
       let hexa = hexagons.find(h => h.isIn(x, y))
@@ -110,6 +111,41 @@ map.load('/map', 962, 924, 0, 0).then(_ => {
         drawer.clean()
         drawer.drawImageScale(0,0,1,map)
         hexa.draw(drawer)
+      }
+    })
+
+    canvas.addEventListener('touchstart', e => {
+      if (e.touches.length > 1) { return; }
+      e.preventDefault()
+    })
+
+    canvas.addEventListener('touchmove', e => {
+      if (e.touches.length > 1) { return; }
+      e.preventDefault()
+      const touch = e.changedTouches[0]
+
+      const { x, y } = translateCoordinate(touch.pageX, touch.pageY)
+
+      let hexa = hexagons.find(h => h.isIn(x, y))
+      if(hexa) {
+        drawer.clean()
+        drawer.drawImageScale(0,0,1,map)
+        hexa.draw(drawer, 80 + touch.radiusY)
+      }
+    })
+
+    canvas.addEventListener('touchend', e => {
+      if (e.touches.length > 1) { return; }
+      const touch = e.changedTouches[0]
+
+      const { x, y } = translateCoordinate(touch.pageX, touch.pageY)
+
+      let hexa = hexagons.find(h => h.isIn(x, y))
+      if(hexa) {
+        drawer.clean()
+        drawer.drawImageScale(0,0,1,map)
+        hexa.draw(drawer)
+        getSurvivors(hexa.coord.x, hexa.coord.y)
       }
     })
 

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -10,6 +10,7 @@ const map = new Images()
 
 const data = document.querySelector("div#data")
 const dataBlueprint = document.querySelector("div.data")
+const dataButton = document.querySelector("button#dataButton")
 
 const stats = document.querySelector("div#stats")
 
@@ -23,6 +24,11 @@ const MetadataRequest = new Request('/metadata', {
 })
 
 const InfoRequest = (x,y) => new Request(`/info?col=${x}&row=${y}`, {
+  method: 'GET',
+  headers: (new Headers()).append('Accept', 'application/json')
+})
+
+const AllInfoRequest = () => new Request(`/allinfo`, {
   method: 'GET',
   headers: (new Headers()).append('Accept', 'application/json')
 })
@@ -54,7 +60,7 @@ function templatingData(inhabitants) {
 }
 
 function getSurvivors(x,y) {
-  fetch(InfoRequest(x,y))
+  ((x && y) ? fetch(InfoRequest(x,y)) : fetch(AllInfoRequest()))
     .then(d => d.json())
     .then(d => {
       while(data.firstChild) {
@@ -74,6 +80,8 @@ function getSurvivors(x,y) {
       }
     })
 }
+
+dataButton.addEventListener('click', e => getSurvivors());
 
 const HexagonColor = "#000000"
 

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -47,14 +47,20 @@ function getSurvivors(x,y) {
     }
     for(const inhab of d) {
       const card = document.createElement('data-card')
-      card.fill({
+      const survivor = {
         Name: inhab.Name,
         Description: inhab.Description,
         Position: `${inhab.Position.x},${inhab.Position.y}`,
         Health: `${inhab.Health}/${inhab.MaxHealth}`,
-        Items: inhab.items.toString().replace(/,/g,', '),
-        Conditions: inhab.condition.toString().replace(/,/g,', ')
-      })
+        Items: inhab.items.toString().replace(/,/g,', ')
+      }
+      if (!inhab.condition.includes("")) {
+        survivor.Conditions = inhab.condition.toString().replace(/,/g,', ')
+      }
+      if (!inhab.profession.includes("")) {
+        survivor.Profession = inhab.profession.toString().replace(/,/g, ', ')
+      }
+      card.fill(survivor)
       card.addEventListener('click', e => {
         let hexa = hexagons.find(hexa => hexa.coord.x === inhab.Position.x && hexa.coord.y === inhab.Position.y)
         if(hexa) {

--- a/src/front/hexagon/hexagon.js
+++ b/src/front/hexagon/hexagon.js
@@ -25,8 +25,12 @@ export default class Hexagon {
     return this.active;
   }
 
-  draw(drawer) {
+  draw(drawer, labelOffset) {
+    if (!labelOffset) labelOffset = 0
     drawer.drawHexagon(this.pos.x, this.pos.y, this.size.x, this.color)
-    drawer.drawTextBoxed(this.pos.x - this.size.x, this.pos.y - this.size.y - 2, `${this.coord.x}, ${this.coord.y}`, this.color, "#000000")
+    drawer.drawTextBoxed(this.pos.x - this.size.x,
+                         this.pos.y - this.size.y - 2 - labelOffset,
+                         `${this.coord.x}, ${this.coord.y}`,
+                         this.color, "#000000")
   }
 }

--- a/src/front/html/index.html
+++ b/src/front/html/index.html
@@ -19,6 +19,7 @@
     <div id="content">
       <canvas id="map">
       </canvas>
+      <button id="dataButton">See All Survivors</button>
       <div id="data">
       </div>
       <div id="stats">

--- a/src/front/html/index.html
+++ b/src/front/html/index.html
@@ -12,6 +12,10 @@
       <div class="row">
         <button id="dataButton">See All Survivors</button><span>Click to highlight the position</span>
       </div>
+      <div class="row">
+        <button id="markButton" class="current">Marked Map</button>
+        <button id="blankButton">Blank Map</button>
+      </div>
       <div id="data">
       </div>
       <div id="stats">

--- a/src/front/html/index.html
+++ b/src/front/html/index.html
@@ -10,7 +10,7 @@
       <ul>
         <li class="Name"></li>
         <li class="Description"></li>
-        <li class="Postion"></li>
+        <li class="Position"></li>
         <li class="Health"></li>
         <li class="Items"></li>
         <li class="Conditions"></li>


### PR DESCRIPTION
To insulate against times like this update where the current turn's link isn't put in the status post, I've added a button to swap back to the blank island map of the status page that we were using before.
Especially if we end up just retrieving "http://willsaveworldforgold.com/starlight/turnX-1.png" files, this structure (maybe with a dropdown?) could be used to flip between each turn's map and watch as the island is explored... but more importantly, this will make sure we can at least have an accurate map when LSN doesn't make it easy.