### PR TITLE
Update parser to read new format for structure contents

### DIFF
--- a/src/back/Crawler.js
+++ b/src/back/Crawler.js
@@ -187,8 +187,10 @@ function parseMultiItems(line) {
   const ItemsRegex = /\d+ [\w *]+,?/g;
   const ItemRegex = /(\d+) ([\w *]+)/;
 
+  const itemsMatch = line.match(ItemsRegex);
+  if (!itemsMatch) return [];
   const items = [];
-  for (const item of line.match(ItemsRegex)) {
+  for (const item of itemsMatch) {
     const itemMatch = item.match(ItemRegex);
     for (let count = 0; count < Number(itemMatch[1]); count++) {
       items.push(itemMatch[2]);
@@ -228,7 +230,7 @@ function structureParser(data) {
   const Structures = new Array();
   const PosRegex = /(\d+), *(\d+) *:/;
   const HealthRegex = /(\d+)\/(\d+) health/;
-  const StorageParser = /storing (.*)$/;
+  const StorageParser = /health(.*)$/;
 
   const lines = data.split(/\n/);
   for (const line of lines) {


### PR DESCRIPTION
Just noticed that structures weren't 'storing' inventory anymore (as of Turn 28, looks like). This version is far more resilient against human changes in typing; it won't pick up '12/8 health' as 8 'health' items, but any instance of (number) (name) after 'health' will be treated as an item listing.