### PR TITLE
feat(Crawler): Parse Follower and items/conditions with non-\w chars

### DIFF
--- a/src/back/Crawler.js
+++ b/src/back/Crawler.js
@@ -36,12 +36,13 @@ function structureTechParser(data) {
  */
 function survivorParser(data) {
   Logger.debug(data);
-  const ConditionsRegex = /Conditions: *((?:\w*[, ]?)*)/;
-  const ItemsRegex = /Items: *((?:\w*[, ]?)*)/;
+  const ConditionsRegex = /Conditions: *([^\n]+)/;
+  const ItemsRegex = /Items: *([^\n]+)/;
   const PosRegex = /Position: *(\d+), *(\d+)/;
   const HealthRegex = /Health: *(\d+)\/(\d+)/;
   const ProfessionRegex = /Profession: *(([\w?]*[, ]?)*)/;
   const ClassRegex = /Class: *(([\w?]* ?)*)/;
+  const FollowerRegex = /Follower: *([^\n]+)/;
   const DescriptionRegex = /\d, ?(.+)$/;
 
   const persoMatch = data.trim().split(/\n ?\n/);
@@ -61,8 +62,18 @@ function survivorParser(data) {
       const conditions = inhabitant.match(ConditionsRegex);
       const profession = inhabitant.match(ProfessionRegex);
       const survivorClass = inhabitant.match(ClassRegex);
+      const follower = inhabitant.match(FollowerRegex);
       const curProfClass = details[1].match(DescriptionRegex);
 
+      const inventory = [];
+      if (items) {
+        items[1].split(/, */).forEach((item) => {
+          inventory.push(item);
+        });
+      }
+      if (follower) {
+        inventory.push(follower[1]);
+      }
       /**
        * @type {[{ Name: string, Level: string }]}
        */
@@ -105,7 +116,7 @@ function survivorParser(data) {
         position ? position[2] : 0,
         health ? health[1] : 0,
         health ? health[2] : 0,
-        items ? items[1].split(/, */) : [],
+        inventory,
         conditions ? conditions[1].split(/, */) : [],
         jobs,
       );
@@ -134,8 +145,8 @@ function survivorParser(data) {
  * @param {String} line The line to parse
  */
 function parseMultiItems(line) {
-  const ItemsRegex = /\d+ [\w *]+,?/g;
-  const ItemRegex = /(\d+) ([\w *]+)/;
+  const ItemsRegex = /\d+ [\w' *]+,?/g;
+  const ItemRegex = /(\d+) ([\w' *]+)/;
 
   const itemsMatch = line.match(ItemsRegex);
   if (!itemsMatch) return [];


### PR DESCRIPTION
Fixes #23. Hardening Conditions and Items, not touching Professions/Classes as we already have the full list and the existing regex matches every one of them.

Also tacking Followers into Items, that's the simplest way to automatically show up in total counts and search. I suppose this does mean that inventory size might seem off.